### PR TITLE
Add support for multiple claims per paper

### DIFF
--- a/_data/defenses.yml
+++ b/_data/defenses.yml
@@ -236,15 +236,15 @@
     - dataset: MNIST
       threat_model: $$\ell_\infty (\epsilon = 0.1)$$
       natural: 98.81% accuracy
-      claim: 96.4% accuracy (on first 1000 test points)
+      claim: (on first 1000 test points) 96.4% accuracy (empirical), 96.37% accuracy (certified)
     - dataset: FMNIST
       threat_model: $$\ell_\infty (\epsilon = 0.1)$$
       natural: 85.50% accuracy
-      claim: 73.4% accuracy (on first 1000 test points)
+      claim: (on first 1000 test points) 73.4% accuracy (empirical), 69.3% accuracy (certified)
     - dataset: GTS
       threat_model: $$\ell_\infty (\epsilon = 0.2)$$
       natural: 84.65% accuracy
-      claim: 67.9% accuracy (on first 1000 test points)
+      claim: (on first 1000 test points) 67.9% accuracy (empirical), 66.8% accuracy (certified)
 -
   name: Harnessing the Vulnerability of Latent Layers in Adversarially Trained Models
   url: https://arxiv.org/abs/1905.05186

--- a/_data/defenses.yml
+++ b/_data/defenses.yml
@@ -237,6 +237,14 @@
       threat_model: $$\ell_\infty (\epsilon = 0.1)$$
       natural: 98.81% accuracy
       claim: 96.4% accuracy (on first 1000 test points)
+    - dataset: FMNIST
+      threat_model: $$\ell_\infty (\epsilon = 0.1)$$
+      natural: 85.50% accuracy
+      claim: 73.4% accuracy (on first 1000 test points)
+    - dataset: GTS
+      threat_model: $$\ell_\infty (\epsilon = 0.2)$$
+      natural: 84.65% accuracy
+      claim: 67.9% accuracy (on first 1000 test points)
 -
   name: Harnessing the Vulnerability of Latent Layers in Adversarially Trained Models
   url: https://arxiv.org/abs/1905.05186

--- a/_data/defenses.yml
+++ b/_data/defenses.yml
@@ -41,16 +41,16 @@
   code: https://github.com/lengstrom/defensive-distillation
   venue: S&P 2016
   venue_date: 2016-05-23
-  dataset: MNIST
-  threat_model: $$\ell_0 (\epsilon = 112)$$
-  natural: 99.51% accuracy
-  claims: >
-    0.45% adversary success rate in changing classifier's prediction
-  analyses:
-    - claims: 3.6% accuracy
-      citation: CW16
-      url: https://arxiv.org/abs/1608.04644
-      code: https://github.com/lengstrom/defensive-distillation
+  claims:
+    - dataset: MNIST
+      threat_model: $$\ell_0 (\epsilon = 112)$$
+      natural: 99.51% accuracy
+      claim: 0.45% adversary success rate in changing classifier's prediction
+      analyses:
+        - claim: 3.6% accuracy
+          citation: CW16
+          url: https://arxiv.org/abs/1608.04644
+          code: https://github.com/lengstrom/defensive-distillation
 -
   name: Deflecting Adversarial Attacks with Pixel Deflection
   url: https://arxiv.org/abs/1801.08926
@@ -58,16 +58,16 @@
   code: https://github.com/anishathalye/pixel-deflection
   venue: CVPR 2018
   venue_date: 2018-06-19
-  dataset: ImageNet
-  threat_model: $$\ell_2 (\epsilon = 0.05)$$
-  natural: 98.9% accuracy (on images originally classified correctly by underlying model)
-  claims: >
-    81% accuracy (on images originally classified correctly)
-  analyses:
-    - claims: 0% accuracy
-      citation: AC18
-      url: https://arxiv.org/abs/1804.03286
-      code: https://github.com/anishathalye/pixel-deflection
+  claims:
+    - dataset: ImageNet
+      threat_model: $$\ell_2 (\epsilon = 0.05)$$
+      natural: 98.9% accuracy (on images originally classified correctly by underlying model)
+      claim: 81% accuracy (on images originally classified correctly)
+      analyses:
+        - claim: 0% accuracy
+          citation: AC18
+          url: https://arxiv.org/abs/1804.03286
+          code: https://github.com/anishathalye/pixel-deflection
 -
   name: Defense against Adversarial Attacks Using High-Level Representation Guided Denoiser
   url: https://arxiv.org/abs/1712.02976
@@ -75,16 +75,16 @@
   code: https://github.com/anishathalye/Guided-Denoise
   venue: CVPR 2018
   venue_date: 2018-06-19
-  dataset: ImageNet
-  threat_model: $$\ell_\infty (\epsilon = 4/255)$$
-  natural: 75% accuracy
-  claims: >
-    75% accuracy
-  analyses:
-    - claims: 0% accuracy
-      citation: AC18
-      url: https://arxiv.org/abs/1804.03286
-      code: https://github.com/anishathalye/guided-denoise
+  claims:
+    - dataset: ImageNet
+      threat_model: $$\ell_\infty (\epsilon = 4/255)$$
+      natural: 75% accuracy
+      claim: 75% accuracy
+      analyses:
+        - claim: 0% accuracy
+          citation: AC18
+          url: https://arxiv.org/abs/1804.03286
+          code: https://github.com/anishathalye/guided-denoise
 -
   name: Towards Deep Learning Models Resistant to Adversarial Attacks
   url: https://arxiv.org/abs/1706.06083
@@ -92,12 +92,11 @@
   code: https://github.com/MadryLab/cifar10_challenge
   venue: ICLR 2018
   venue_date: 2018-04-30
-  dataset: CIFAR-10
-  threat_model: $$\ell_\infty (\epsilon = 8/255)$$
-  natural: 87% accuracy
-  claims: >
-    46% accuracy
-  analyses:
+  claims:
+    - dataset: CIFAR&#8209;10
+      threat_model: $$\ell_\infty (\epsilon = 8/255)$$
+      natural: 87% accuracy
+      claim: 46% accuracy
 -
   name: Provable defenses against adversarial examples via the convex outer adversarial polytope
   url: https://arxiv.org/abs/1711.00851
@@ -105,12 +104,11 @@
   code: https://github.com/dtsip/convex_adversarial
   venue: ICML 2018
   venue_date: 2018-07-11
-  dataset: MNIST
-  threat_model: $$\ell_\infty (\epsilon = 0.1)$$
-  natural: 98.2% accuracy
-  claims: >
-    94.2% accuracy
-  analyses:
+  claims:
+    - dataset: MNIST
+      threat_model: $$\ell_\infty (\epsilon = 0.1)$$
+      natural: 98.2% accuracy
+      claim: 94.2% accuracy
 -
   name: Mitigating Adversarial Effects Through Randomization
   url: https://arxiv.org/abs/1711.01991
@@ -118,16 +116,16 @@
   code: https://github.com/anishathalye/obfuscated-gradients/tree/master/randomization
   venue: ICLR 2018
   venue_date: 2018-04-30
-  dataset: ImageNet
-  threat_model: $$\ell_\infty (\epsilon = 10/255)$$
-  natural: 99.2% accuracy (on images originally classified correctly by underlying model)
-  claims: >
-    86% accuracy (on images originally classified correctly)
-  analyses:
-    - claims: 0% accuracy
-      citation: ACW18
-      url: https://arxiv.org/abs/1802.00420
-      code: https://github.com/anishathalye/obfuscated-gradients/tree/master/randomization
+  claims:
+    - dataset: ImageNet
+      threat_model: $$\ell_\infty (\epsilon = 10/255)$$
+      natural: 99.2% accuracy (on images originally classified correctly by underlying model)
+      claim: 86% accuracy (on images originally classified correctly)
+      analyses:
+        - claim: 0% accuracy
+          citation: ACW18
+          url: https://arxiv.org/abs/1802.00420
+          code: https://github.com/anishathalye/obfuscated-gradients/tree/master/randomization
 -
   name: "Thermometer Encoding: One Hot Way To Resist Adversarial Examples"
   url: https://openreview.net/forum?id=S18Su--CW
@@ -135,17 +133,17 @@
   code: https://github.com/anishathalye/obfuscated-gradients/tree/master/thermometer
   venue: ICLR 2018
   venue_date: 2018-04-30
-  dataset: CIFAR-10
-  threat_model: $$\ell_\infty (\epsilon = 8/255)$$
-  natural: 90% accuracy
-  claims: >
-    79% accuracy
-# adversarially trained variant
-  analyses:
-    - claims: 30% accuracy
-      citation: ACW18
-      url: https://arxiv.org/abs/1802.00420
-      code: https://github.com/anishathalye/obfuscated-gradients/tree/master/thermometer
+  claims:
+    - dataset: CIFAR&#8209;10
+      threat_model: $$\ell_\infty (\epsilon = 8/255)$$
+      natural: 90% accuracy
+      claim: 79% accuracy
+      # adversarially trained variant
+      analyses:
+        - claim: 30% accuracy
+          citation: ACW18
+          url: https://arxiv.org/abs/1802.00420
+          code: https://github.com/anishathalye/obfuscated-gradients/tree/master/thermometer
 -
   name: Countering Adversarial Images using Input Transformations
   url: https://arxiv.org/abs/1711.00117
@@ -153,17 +151,16 @@
   code: https://github.com/anishathalye/obfuscated-gradients/tree/master/inputtransformations
   venue: ICLR 2018
   venue_date: 2018-04-30
-  dataset: ImageNet
-  threat_model: $$\ell_2 (\epsilon = 0.06)$$
-  natural: 75% accuracy
-  claims: >
-    70% accuracy on ImageNet with average normalized $$\ell_2$$ perturbation of
-    0.06
-  analyses:
-    - claims: 0% accuracy
-      citation: ACW18
-      url: https://arxiv.org/abs/1802.00420
-      code: https://github.com/anishathalye/obfuscated-gradients/tree/master/inputtransformations
+  claims:
+    - dataset: ImageNet
+      threat_model: $$\ell_2 (\epsilon = 0.06)$$
+      natural: 75% accuracy
+      claim: 70% accuracy on ImageNet with average normalized $$\ell_2$$ perturbation of 0.06
+      analyses:
+        - claim: 0% accuracy
+          citation: ACW18
+          url: https://arxiv.org/abs/1802.00420
+          code: https://github.com/anishathalye/obfuscated-gradients/tree/master/inputtransformations
 -
   name: Stochastic Activation Pruning for Robust Adversarial Defense
   url: https://arxiv.org/abs/1803.01442
@@ -171,16 +168,16 @@
   code: https://github.com/anishathalye/obfuscated-gradients/tree/master/sap
   venue: ICLR 2018
   venue_date: 2018-04-30
-  dataset: CIFAR-10
-  threat_model: $$\ell_\infty (\epsilon = 4/255)$$
-  natural: 83% accuracy
-  claims: >
-    51% accuracy
-  analyses:
-    - claims: 0% accuracy
-      citation: ACW18
-      url: https://arxiv.org/abs/1802.00420
-      code: https://github.com/anishathalye/obfuscated-gradients/tree/master/sap
+  claims:
+    - dataset: CIFAR&#8209;10
+      threat_model: $$\ell_\infty (\epsilon = 4/255)$$
+      natural: 83% accuracy
+      claim: 51% accuracy
+      analyses:
+        - claim: 0% accuracy
+          citation: ACW18
+          url: https://arxiv.org/abs/1802.00420
+          code: https://github.com/anishathalye/obfuscated-gradients/tree/master/sap
 -
   name: "PixelDefend: Leveraging Generative Models to Understand and Defend against Adversarial Examples"
   url: https://arxiv.org/abs/1710.10766
@@ -188,16 +185,16 @@
   code: https://github.com/anishathalye/obfuscated-gradients/tree/master/pixeldefend
   venue: ICLR 2018
   venue_date: 2018-04-30
-  dataset: CIFAR-10
-  threat_model: $$\ell_\infty (\epsilon = 8/255)$$
-  natural: 90% accuracy
-  claims: >
-    70% accuracy
-  analyses:
-    - claims: 9% accuracy
-      citation: ACW18
-      url: https://arxiv.org/abs/1802.00420
-      code: https://github.com/anishathalye/obfuscated-gradients/tree/master/pixeldefend
+  claims:
+    - dataset: CIFAR&#8209;10
+      threat_model: $$\ell_\infty (\epsilon = 8/255)$$
+      natural: 90% accuracy
+      claim: 70% accuracy
+      analyses:
+        - claim: 9% accuracy
+          citation: ACW18
+          url: https://arxiv.org/abs/1802.00420
+          code: https://github.com/anishathalye/obfuscated-gradients/tree/master/pixeldefend
 # TODO include Defense-GAN once there is a robustml implementation for it
 #-
   #name: "Defense-GAN: Protecting Classifiers Against Adversarial Attacks Using Generative Models"
@@ -223,10 +220,11 @@
   code: https://github.com/bethgelab/AnalysisBySynthesis
   venue: NeurIPS SECML 2018
   venue_date: 2018-12-07
-  dataset: MNIST
-  threat_model: $$\ell_2 (\epsilon = 1.5)$$
-  natural: 99% accuracy
-  claims: 80% accuracy
+  claims:
+    - dataset: MNIST
+      threat_model: $$\ell_2 (\epsilon = 1.5)$$
+      natural: 99% accuracy
+      claim: 80% accuracy
 -
   name: Provable Robustness of ReLU networks via Maximization of Linear Regions
   url: https://arxiv.org/abs/1810.07481
@@ -234,10 +232,11 @@
   code: https://github.com/max-andr/provable-robustness-max-linear-regions
   venue: AISTATS 2019
   venue_date: 2019-04-16
-  dataset: MNIST
-  threat_model: $$\ell_\infty (\epsilon = 0.1)$$
-  natural: 98.81% accuracy
-  claims: 96.4% accuracy (on first 1000 test points)
+  claims:
+    - dataset: MNIST
+      threat_model: $$\ell_\infty (\epsilon = 0.1)$$
+      natural: 98.81% accuracy
+      claim: 96.4% accuracy (on first 1000 test points)
 -
   name: Harnessing the Vulnerability of Latent Layers in Adversarially Trained Models
   url: https://arxiv.org/abs/1905.05186
@@ -245,7 +244,8 @@
   code: https://github.com/conference-submission-anon/LAT_adversarial_robustness
   venue: IJCAI 2019
   venue_date: 2019-08-10
-  dataset: CIFAR-10
-  threat_model: $$\ell_\infty (\epsilon = 0.03)$$
-  natural: 87.8% accuracy
-  claims: 53.82% accuracy
+  claims:
+    - dataset: CIFAR&#8209;10
+      threat_model: $$\ell_\infty (\epsilon = 0.03)$$
+      natural: 87.8% accuracy
+      claim: 53.82% accuracy

--- a/_data/defenses.yml
+++ b/_data/defenses.yml
@@ -236,7 +236,7 @@
     - dataset: MNIST
       threat_model: $$\ell_\infty (\epsilon = 0.1)$$
       natural: 98.81% accuracy
-      claim: (on first 1000 test points) 96.4% accuracy (empirical), 96.37% accuracy (certified)
+      claim: 96.42% accuracy (empirical), 96.37% accuracy (certified)
     - dataset: FMNIST
       threat_model: $$\ell_\infty (\epsilon = 0.1)$$
       natural: 85.50% accuracy

--- a/_data/preprints.yml
+++ b/_data/preprints.yml
@@ -4,40 +4,41 @@
   upload_date: 2018-03-16
   authors: Kannan et al.
   code: https://github.com/labsix/adversarial-logit-pairing-analysis
-  dataset: ImageNet
-  threat_model: $$\ell_\infty (\epsilon = 16/255)$$
-  natural: 72%
-  claims: >
-    27.9% accuracy
-  analyses:
-    - claims: 0.1% accuracy
-      citation: EIA18
-      url: https://arxiv.org/abs/1807.10272
-      code: https://github.com/labsix/adversarial-logit-pairing-analysis
-      note: >
-        This analysis has been performed on the ImageNet 64x64 model released
-        at
-        https://&#8203;github.com/&#8203;tensorflow/&#8302;models/&#8302;tree/&#8302;master/&#8302;research/&#8302;adversarial_logit_pairing.
-        The authors claim to have unreleased models that may be more secure.
+  claims:
+    - dataset: ImageNet
+      threat_model: $$\ell_\infty (\epsilon = 16/255)$$
+      natural: 72%
+      claim: 27.9% accuracy
+      analyses:
+        - claim: 0.1% accuracy
+          citation: EIA18
+          url: https://arxiv.org/abs/1807.10272
+          code: https://github.com/labsix/adversarial-logit-pairing-analysis
+          note: >
+            This analysis has been performed on the ImageNet 64x64 model released
+            at
+            https://&#8203;github.com/&#8203;tensorflow/&#8302;models/&#8302;tree/&#8302;master/&#8302;research/&#8302;adversarial_logit_pairing.
+            The authors claim to have unreleased models that may be more secure.
 -
   name: Combatting and detecting FGSM and PGD adversarial noise
   url: https://jngannon.github.io/FGSM_Article
   upload_date: 2019-01-25
   authors: James Gannon
   code: https://github.com/jngannon/robustml-test-analysis
-  dataset: MNIST
-  threat_model: $$\ell_\infty (\epsilon = 0.1)$$
-  natural: 98.2%
-  claims: >
-    78.2% accuracy
-  analyses:
+  claims:
+    - dataset: MNIST
+      threat_model: $$\ell_\infty (\epsilon = 0.1)$$
+      natural: 98.2%
+      claim: 78.2% accuracy
+      analyses:
 -
   name: Adversarial Defense by Restricting the Hidden Space of Deep Neural Networks
   upload_date: 2019-04-01
   url: https://arxiv.org/abs/1904.00887
   authors: Mustafa et al.
   code: https://github.com/aamir-mustafa/pcl-adversarial-defense
-  dataset: CIFAR-10
-  threat_model: $$\ell_\infty (\epsilon = 8/255)$$
-  natural: 90.62% accuracy
-  claims: 32.32% accuracy
+  claims:
+    - dataset: CIFAR&#8209;10
+      threat_model: $$\ell_\infty (\epsilon = 8/255)$$
+      natural: 90.62% accuracy
+      claim: 32.32% accuracy

--- a/_includes/table.html
+++ b/_includes/table.html
@@ -51,8 +51,13 @@
       fixedHeader: true,
       paging: false,
       info: false,
-      order: [[0, 'asc']],
-      rowsGroup: [0],
+      {% if include.published %}
+        rowsGroup: [0, 1],
+        order: [[0, 'desc']], // XXX not sure why this has to be desc, but it seems to work
+      {% else %}
+        order: [[0, 'asc']],
+        rowsGroup: [0],
+      {% endif %}
       drawCallback: function(settings) {
         MathJax.Hub.Queue(["Typeset",MathJax.Hub]);
       },

--- a/_includes/table.html
+++ b/_includes/table.html
@@ -46,6 +46,7 @@
   $(document).ready(function() {
     $('#table').DataTable({
       responsive: true,
+      fixedHeader: true,
       paging: false,
       info: false,
       {% if include.published %}

--- a/_includes/table.html
+++ b/_includes/table.html
@@ -2,13 +2,13 @@
   <thead>
     <tr>
       {% if include.published %}
-        <th data-priority="1" data-orderable="false">Defense</th>
-        <th data-priority="7">Venue</th>
+        <th data-priority="1">Defense</th>
+        <th data-priority="7" data-orderable="false">Venue</th>
       {% else %}
         <th data-priority="1">Defense</th>
       {% endif %}
-      <th data-priority="3">Dataset</th>
-      <th data-priority="4">Threat Model</th>
+      <th data-priority="3" data-orderable="false">Dataset</th>
+      <th data-priority="4" data-orderable="false">Threat Model</th>
       <th data-priority="6" data-orderable="false">Natural Accuracy</th>
       <th data-priority="5" data-orderable="false">Claims</th>
       <th data-priority="2" data-orderable="false">Analyses</th>
@@ -16,28 +16,30 @@
   </thead>
   <tbody>
     {% for row in include.src %}
-      <tr>
-        {% if include.published %}
-        <td>
-        {% else %}
-          <td data-sort="{{ row.upload_date }}">
-        {% endif %}
-          <a href="{{ row.url }}">{{ row.name }}</a> ({{ row.authors }}) (<a href="{{ row.code }}">code</a>)
-        </td>
-        {% if include.published %}
-          <td data-sort="{{ row.venue_date }}">{{ row.venue }}</td>
-        {% endif %}
-        <td>{{ row.dataset }}</td>
-        <td>{{ row.threat_model }}</td>
-        <td>{{ row.natural | markdownify }}</td>
-        <td>{{ row.claims | markdownify }}</td>
-        <td>
-          <ul class="analyses">
-          {% for analysis in row.analyses %}
-            <li>{{ analysis.claims }} [<a href="{{ analysis.url }}">{{ analysis.citation }}</a>] (<a href="{{ analysis.code }}">code</a>){% if analysis.note %} <span class='footnote' data-toggle="tooltip" title="{{ analysis.note }}"></span>{% endif %}</li>
-          {% endfor %}
-        </td>
-      </tr>
+      {% for claim in row.claims %}
+        <tr>
+          {% if include.published %}
+            <td data-sort="{{ row.venue_date }}">
+          {% else %}
+            <td data-sort="{{ row.upload_date }}">
+          {% endif %}
+            <a href="{{ row.url }}">{{ row.name }}</a> ({{ row.authors }}) (<a href="{{ row.code }}">code</a>)
+          </td>
+          {% if include.published %}
+            <td>{{ row.venue }}</td>
+          {% endif %}
+          <td>{{ claim.dataset }}</td>
+          <td>{{ claim.threat_model }}</td>
+          <td>{{ claim.natural | markdownify }}</td>
+          <td>{{ claim.claim | markdownify }}</td>
+          <td>
+            <ul class="analyses">
+            {% for analysis in claim.analyses %}
+              <li>{{ analysis.claim }} [<a href="{{ analysis.url }}">{{ analysis.citation }}</a>] (<a href="{{ analysis.code }}">code</a>){% if analysis.note %} <span class='footnote' data-toggle="tooltip" title="{{ analysis.note }}"></span>{% endif %}</li>
+            {% endfor %}
+          </td>
+        </tr>
+      {% endfor %}
     {% endfor %}
   </tbody>
 </table>
@@ -49,11 +51,8 @@
       fixedHeader: true,
       paging: false,
       info: false,
-      {% if include.published %}
-        order: [[1, 'desc']],
-      {% else %}
-        order: [[0, 'desc']],
-      {% endif %}
+      order: [[0, 'asc']],
+      rowsGroup: [0],
       drawCallback: function(settings) {
         MathJax.Hub.Queue(["Typeset",MathJax.Hub]);
       },

--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -15,7 +15,7 @@ layout: null
     <meta charset="utf-8">
     <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
     <link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/bootstrap/4.0.0/css/bootstrap.min.css" integrity="sha384-Gn5384xqQ1aoWXA+058RXPxPg6fy4IWvTNh0E263XmFcJlSAwiGgFAW/dAiS6JXm" crossorigin="anonymous">
-    <link rel="stylesheet" type="text/css" href="https://cdn.datatables.net/v/bs4/dt-1.10.16/r-2.2.1/datatables.min.css" crossorigin="anonymous">
+    <link rel="stylesheet" type="text/css" href="https://cdn.datatables.net/v/bs4/dt-1.10.18/fh-3.1.4/r-2.2.2/datatables.min.css" crossorigin="anonymous">
     <link href="https://fonts.googleapis.com/css?family=Lato" rel="stylesheet">
     <link rel="stylesheet" href="/css/main.css">
     <link rel="apple-touch-icon" sizes="180x180" href="/apple-touch-icon.png">
@@ -64,7 +64,7 @@ layout: null
     <script src="https://code.jquery.com/jquery-3.2.1.slim.min.js" integrity="sha384-KJ3o2DKtIkvYIK3UENzmM7KCkRr/rE9/Qpg6aAZGJwFDMVNA/GpGFF93hXpG5KkN" crossorigin="anonymous"></script>
     <script src="https://cdnjs.cloudflare.com/ajax/libs/popper.js/1.12.9/umd/popper.min.js" integrity="sha384-ApNbgh9B+Y1QKtv3Rn7W3mgPxhU9K/ScQsAP7hUibX39j7fakFPskvXusvfa0b4Q" crossorigin="anonymous"></script>
     <script src="https://maxcdn.bootstrapcdn.com/bootstrap/4.0.0/js/bootstrap.min.js" integrity="sha384-JZR6Spejh4U02d8jOt6vLEHfe/JQGiRRSQQxSfFWpi1MquVdAyjUar5+76PVCmYl" crossorigin="anonymous"></script>
-    <script type="text/javascript" src="https://cdn.datatables.net/v/bs4/dt-1.10.16/r-2.2.1/datatables.min.js" crossorigin="anonymous"></script>
+    <script type="text/javascript" src="https://cdn.datatables.net/v/bs4/dt-1.10.18/fh-3.1.4/r-2.2.2/datatables.min.js" crossorigin="anonymous"></script>
     <nav class="navbar navbar-expand-sm navbar-dark bg-dark mb-4">
       <button class="navbar-toggler" type="button" data-toggle="collapse" data-target="#navbarCollapse" aria-controls="navbarCollapse" aria-expanded="false" aria-label="Toggle navigation">
         <span class="navbar-toggler-icon"></span>

--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -65,6 +65,7 @@ layout: null
     <script src="https://cdnjs.cloudflare.com/ajax/libs/popper.js/1.12.9/umd/popper.min.js" integrity="sha384-ApNbgh9B+Y1QKtv3Rn7W3mgPxhU9K/ScQsAP7hUibX39j7fakFPskvXusvfa0b4Q" crossorigin="anonymous"></script>
     <script src="https://maxcdn.bootstrapcdn.com/bootstrap/4.0.0/js/bootstrap.min.js" integrity="sha384-JZR6Spejh4U02d8jOt6vLEHfe/JQGiRRSQQxSfFWpi1MquVdAyjUar5+76PVCmYl" crossorigin="anonymous"></script>
     <script type="text/javascript" src="https://cdn.datatables.net/v/bs4/dt-1.10.18/fh-3.1.4/r-2.2.2/datatables.min.js" crossorigin="anonymous"></script>
+    <script type="text/javascript" src="/vendor/js/dataTables.rowsGroup.js"></script>
     <nav class="navbar navbar-expand-sm navbar-dark bg-dark mb-4">
       <button class="navbar-toggler" type="button" data-toggle="collapse" data-target="#navbarCollapse" aria-controls="navbarCollapse" aria-expanded="false" aria-label="Toggle navigation">
         <span class="navbar-toggler-icon"></span>

--- a/vendor/js/dataTables.rowsGroup.js
+++ b/vendor/js/dataTables.rowsGroup.js
@@ -1,0 +1,285 @@
+/*! RowsGroup for DataTables v2.0.0
+ * 2015-2016 Alexey Shildyakov ashl1future@gmail.com
+ * 2016 Tibor Wekerle
+ */
+
+/**
+ * @summary     RowsGroup
+ * @description Group rows by specified columns
+ * @version     2.0.0
+ * @file        dataTables.rowsGroup.js
+ * @author      Alexey Shildyakov (ashl1future@gmail.com)
+ * @contact     ashl1future@gmail.com
+ * @copyright   Alexey Shildyakov
+ * 
+ * License      MIT - http://datatables.net/license/mit
+ *
+ * This feature plug-in for DataTables automatically merges columns cells
+ * based on it's values equality. It supports multi-column row grouping
+ * in according to the requested order with dependency from each previous 
+ * requested columns. Now it supports ordering and searching. 
+ * Please see the example.html for details.
+ * 
+ * Rows grouping in DataTables can be enabled by using any one of the following
+ * options:
+ *
+ * * Setting the `rowsGroup` parameter in the DataTables initialisation
+ *   to array which containes columns selectors
+ *   (https://datatables.net/reference/type/column-selector) used for grouping. i.e.
+ *    rowsGroup = [1, 'columnName:name', ]
+ * * Setting the `rowsGroup` parameter in the DataTables defaults
+ *   (thus causing all tables to have this feature) - i.e.
+ *   `$.fn.dataTable.defaults.RowsGroup = [0]`.
+ * * Creating a new instance: `new $.fn.dataTable.RowsGroup( table, columnsForGrouping );`
+ *   where `table` is a DataTable's API instance and `columnsForGrouping` is the array
+ *   described above.
+ *
+ * For more detailed information please see:
+ *     
+ */
+
+(function($){
+
+ShowedDataSelectorModifier = {
+	order: 'current',
+	page: 'current',
+	search: 'applied',
+}
+
+GroupedColumnsOrderDir = 'asc';
+
+
+/*
+ * columnsForGrouping: array of DTAPI:cell-selector for columns for which rows grouping is applied
+ */
+var RowsGroup = function ( dt, columnsForGrouping )
+{
+	this.table = dt.table();
+	this.columnsForGrouping = columnsForGrouping;
+	 // set to True when new reorder is applied by RowsGroup to prevent order() looping
+	this.orderOverrideNow = false;
+	this.mergeCellsNeeded = false; // merge after init
+	this.order = []
+	
+	var self = this;
+	dt.on('order.dt', function ( e, settings) {
+		if (!self.orderOverrideNow) {
+			self.orderOverrideNow = true;
+			self._updateOrderAndDraw()
+		} else {
+			self.orderOverrideNow = false;
+		}
+	})
+	
+	dt.on('preDraw.dt', function ( e, settings) {
+		if (self.mergeCellsNeeded) {
+			self.mergeCellsNeeded = false;
+			self._mergeCells()
+		}
+	})
+	
+	dt.on('column-visibility.dt', function ( e, settings) {
+		self.mergeCellsNeeded = true;
+	})
+
+	dt.on('search.dt', function ( e, settings) {
+		// This might to increase the time to redraw while searching on tables
+		//   with huge shown columns
+		self.mergeCellsNeeded = true;
+	})
+
+	dt.on('page.dt', function ( e, settings) {
+		self.mergeCellsNeeded = true;
+	})
+
+	dt.on('length.dt', function ( e, settings) {
+		self.mergeCellsNeeded = true;
+	})
+
+	dt.on('xhr.dt', function ( e, settings) {
+		self.mergeCellsNeeded = true;
+	})
+
+	this._updateOrderAndDraw();
+	
+/* Events sequence while Add row (also through Editor)
+ * addRow() function
+ *   draw() function
+ *     preDraw() event
+ *       mergeCells() - point 1
+ *     Appended new row breaks visible elements because the mergeCells() on previous step doesn't apllied to already processing data
+ *   order() event
+ *     _updateOrderAndDraw()
+ *       preDraw() event
+ *         mergeCells()
+ *       Appended new row now has properly visibility as on current level it has already applied changes from first mergeCells() call (point 1)
+ *   draw() event
+ */
+};
+
+
+RowsGroup.prototype = {
+	setMergeCells: function(){
+		this.mergeCellsNeeded = true;
+	},
+
+	mergeCells: function()
+	{
+		this.setMergeCells();
+		this.table.draw();
+	},
+
+	_getOrderWithGroupColumns: function (order, groupedColumnsOrderDir)
+	{
+		if (groupedColumnsOrderDir === undefined)
+			groupedColumnsOrderDir = GroupedColumnsOrderDir
+			
+		var self = this;
+		var groupedColumnsIndexes = this.columnsForGrouping.map(function(columnSelector){
+			return self.table.column(columnSelector).index()
+		})
+		var groupedColumnsKnownOrder = order.filter(function(columnOrder){
+			return groupedColumnsIndexes.indexOf(columnOrder[0]) >= 0
+		})
+		var nongroupedColumnsOrder = order.filter(function(columnOrder){
+			return groupedColumnsIndexes.indexOf(columnOrder[0]) < 0
+		})
+		var groupedColumnsKnownOrderIndexes = groupedColumnsKnownOrder.map(function(columnOrder){
+			return columnOrder[0]
+		})
+		var groupedColumnsOrder = groupedColumnsIndexes.map(function(iColumn){
+			var iInOrderIndexes = groupedColumnsKnownOrderIndexes.indexOf(iColumn)
+			if (iInOrderIndexes >= 0)
+				return [iColumn, groupedColumnsKnownOrder[iInOrderIndexes][1]]
+			else
+				return [iColumn, groupedColumnsOrderDir]
+		})
+		
+		groupedColumnsOrder.push.apply(groupedColumnsOrder, nongroupedColumnsOrder)
+		return groupedColumnsOrder;
+	},
+ 
+	// Workaround: the DT reset ordering to 'asc' from multi-ordering if user order on one column (without shift)
+	//   but because we always has multi-ordering due to grouped rows this happens every time
+	_getInjectedMonoSelectWorkaround: function(order)
+	{
+		if (order.length === 1) {
+			// got mono order - workaround here
+			var orderingColumn = order[0][0]
+			var previousOrder = this.order.map(function(val){
+				return val[0]
+			})
+			var iColumn = previousOrder.indexOf(orderingColumn);
+			if (iColumn >= 0) {
+				// assume change the direction, because we already has that in previos order
+				return [[orderingColumn, this._toogleDirection(this.order[iColumn][1])]]
+			} // else This is the new ordering column. Proceed as is.
+		} // else got milti order - work normal
+		return order;
+	},
+	
+	_mergeCells: function()
+	{
+		var columnsIndexes = this.table.columns(this.columnsForGrouping, ShowedDataSelectorModifier).indexes().toArray()
+		var showedRowsCount = this.table.rows(ShowedDataSelectorModifier)[0].length 
+		this._mergeColumn(0, showedRowsCount - 1, columnsIndexes)
+	},
+	
+	// the index is relative to the showed data
+	//    (selector-modifier = {order: 'current', page: 'current', search: 'applied'}) index
+	_mergeColumn: function(iStartRow, iFinishRow, columnsIndexes)
+	{
+		var columnsIndexesCopy = columnsIndexes.slice()
+		currentColumn = columnsIndexesCopy.shift()
+		currentColumn = this.table.column(currentColumn, ShowedDataSelectorModifier)
+		
+		var columnNodes = currentColumn.nodes()
+		var columnValues = currentColumn.data()
+		
+		var newSequenceRow = iStartRow,
+			iRow;
+		for (iRow = iStartRow + 1; iRow <= iFinishRow; ++iRow) {
+			
+			if (columnValues[iRow] === columnValues[newSequenceRow]) {
+				$(columnNodes[iRow]).hide()
+			} else {
+				$(columnNodes[newSequenceRow]).show()
+				$(columnNodes[newSequenceRow]).attr('rowspan', (iRow-1) - newSequenceRow + 1)
+				
+				if (columnsIndexesCopy.length > 0)
+					this._mergeColumn(newSequenceRow, (iRow-1), columnsIndexesCopy)
+				
+				newSequenceRow = iRow;
+			}
+			
+		}
+		$(columnNodes[newSequenceRow]).show()
+		$(columnNodes[newSequenceRow]).attr('rowspan', (iRow-1)- newSequenceRow + 1)
+		if (columnsIndexesCopy.length > 0)
+			this._mergeColumn(newSequenceRow, (iRow-1), columnsIndexesCopy)
+	},
+	
+	_toogleDirection: function(dir)
+	{
+		return dir == 'asc'? 'desc': 'asc';
+	},
+ 
+	_updateOrderAndDraw: function()
+	{
+		this.mergeCellsNeeded = true;
+		
+		var currentOrder = this.table.order();
+		currentOrder = this._getInjectedMonoSelectWorkaround(currentOrder);
+		this.order = this._getOrderWithGroupColumns(currentOrder)
+		this.table.order($.extend(true, Array(), this.order))
+		this.table.draw()
+	},
+};
+
+
+$.fn.dataTable.RowsGroup = RowsGroup;
+$.fn.DataTable.RowsGroup = RowsGroup;
+
+// Automatic initialisation listener
+$(document).on( 'init.dt', function ( e, settings ) {
+	if ( e.namespace !== 'dt' ) {
+		return;
+	}
+
+	var api = new $.fn.dataTable.Api( settings );
+	
+	if ( settings.oInit.rowsGroup ||
+		 $.fn.dataTable.defaults.rowsGroup )
+	{
+		options = settings.oInit.rowsGroup?
+			settings.oInit.rowsGroup:
+			$.fn.dataTable.defaults.rowsGroup;
+		var rowsGroup = new RowsGroup( api, options );
+		$.fn.dataTable.Api.register( 'rowsgroup.update()', function () {
+			rowsGroup.mergeCells();
+			return this;
+		} );
+		$.fn.dataTable.Api.register( 'rowsgroup.updateNextDraw()', function () {
+			rowsGroup.setMergeCells();
+			return this;
+		} );
+	}
+} );
+
+}(jQuery));
+
+/*
+
+TODO: Provide function which determines the all <tr>s and <td>s with "rowspan" html-attribute is parent (groupped) for the specified <tr> or <td>. To use in selections, editing or hover styles.
+
+TODO: Feature
+Use saved order direction for grouped columns
+	Split the columns into grouped and ungrouped.
+	
+	user = grouped+ungrouped
+	grouped = grouped
+	saved = grouped+ungrouped
+	
+	For grouped uses following order: user -> saved (because 'saved' include 'grouped' after first initialisation). This should be done with saving order like for 'groupedColumns'
+	For ungrouped: uses only 'user' input ordering
+*/


### PR DESCRIPTION
As the title says.

This change gets rid of sorting on threat model / dataset (it wasn't all that useful anyways, in my opinion; filtering still works). It also adds a sticky header.

This change also includes an example of multiple claims per paper (from #4).

cc @max-andr